### PR TITLE
Some additions implementing corrections from HMcode2020

### DIFF
--- a/src/halomod/concentration.py
+++ b/src/halomod/concentration.py
@@ -69,7 +69,7 @@ from hmf.halos.mass_definitions import (
 )
 from scipy import special as sp
 from scipy.interpolate import interp1d
-from scipy.optimize import minimize
+from scipy.optimize import minimize, root_scalar
 
 from .profiles import NFW, Profile
 
@@ -218,6 +218,51 @@ def make_colossus_cm(model="diemer15", **defaults):
     CustomColossusCM.__qualname__ = model.capitalize()
 
     return CustomColossusCM
+    
+    
+def get_modified_concentration(base):
+    r"""
+    A factory function that modifies every concentration class in halomod 
+    with an aditional normalisation
+    """
+    
+    class NormConc(base):
+        r"""
+        Additional normalisation to any concentration-mass relation.
+    
+        This additional normalisation has 3 input parameters.
+    
+        Notes
+        -----
+        Parameters
+        ----------------
+        norm, sigma8, ns: float
+            Default value is ``norm=1.0``, ``sigma8=0.8`` and ``ns=1.0``
+        """
+    
+        _defaults = base._defaults
+        native_mdefs = base.native_mdefs
+        
+        def __init__(self, norm=1.0, sigma8=0.8, ns=1.0, **model_parameters):
+            self.norm = norm
+            self.sigma8 = sigma8
+            self.ns = ns
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', category=UserWarning)
+                super(base, self).__init__(**model_parameters)
+                # if passing colossus c(M) relation, this takes care of correct sigma8 and ns parameters
+                fromAstropy(self.cosmo.cosmo, sigma8=self.sigma8, ns=self.ns, cosmo_name='', persistence='')
+    
+        def cm(self, m, z):
+            c = base.cm(self, m, z)
+            if len(c[c>0]) == 0:
+                c_interp = lambda x: np.ones_like(x)
+            else:
+                c_interp = interp1d(m[c>0], c[c>0], kind='linear', bounds_error=False, fill_value=1.0)
+                
+            return c_interp(m) * self.norm
+            
+    return NormConc
 
 
 class Bullock01(CMRelation):
@@ -252,9 +297,20 @@ class Bullock01(CMRelation):
     def zc(self, m, z=0):
         r = self.filter.mass_to_radius(self.params["F"] * m, self.mean_density0)
         nu = self.filter.nu(r, self.delta_c)
-        g = self.growth.growth_factor_fn(inverse=True)
-        zc = g(np.sqrt(nu))
-        zc[zc < z] = z  # hack?
+        #g = self.growth.growth_factor_fn(inverse=True)
+        #zc = g(np.sqrt(nu)) # This causes troubles with CambGrowth as it is non-monotonic
+        #zc[zc < z] = z  # hack?
+        g = self.growth.growth_factor_fn()
+        zc = np.zeros_like(m)
+        for i in range(m.size):
+            fzc = g(z) * np.sqrt(nu[i])
+            if fzc < g(z):
+                zf = z # These haloes formed 'in the future'
+            else:
+                zf_root = lambda x: g(x) - fzc
+                zf = root_scalar(zf_root, bracket=(1e-9, 1000.0)).root
+            zc[i] = zf
+            print(zf)
         return zc
 
     def cm(self, m, z=0):

--- a/src/halomod/concentration.py
+++ b/src/halomod/concentration.py
@@ -69,7 +69,7 @@ from hmf.halos.mass_definitions import (
 )
 from scipy import special as sp
 from scipy.interpolate import interp1d
-from scipy.optimize import minimize, root_scalar
+from scipy.optimize import minimize
 
 from .profiles import NFW, Profile
 
@@ -297,20 +297,9 @@ class Bullock01(CMRelation):
     def zc(self, m, z=0):
         r = self.filter.mass_to_radius(self.params["F"] * m, self.mean_density0)
         nu = self.filter.nu(r, self.delta_c)
-        #g = self.growth.growth_factor_fn(inverse=True)
-        #zc = g(np.sqrt(nu)) # This causes troubles with CambGrowth as it is non-monotonic
-        #zc[zc < z] = z  # hack?
-        g = self.growth.growth_factor_fn()
-        zc = np.zeros_like(m)
-        for i in range(m.size):
-            fzc = g(z) * np.sqrt(nu[i])
-            if fzc < g(z):
-                zf = z # These haloes formed 'in the future'
-            else:
-                zf_root = lambda x: g(x) - fzc
-                zf = root_scalar(zf_root, bracket=(1e-9, 1000.0)).root
-            zc[i] = zf
-            print(zf)
+        g = self.growth.growth_factor_fn(inverse=True)
+        zc = g(np.sqrt(nu)) # This causes troubles with CambGrowth as it is non-monotonic
+        zc[zc < z] = z  # hack?
         return zc
 
     def cm(self, m, z=0):

--- a/src/halomod/halo_model.py
+++ b/src/halomod/halo_model.py
@@ -398,6 +398,7 @@ class DMHaloModel(MassFunction):
             cm_relation=self.halo_concentration,
             mdef=self.mdef,
             z=self.z,
+            sqrt_nu=self.nu**0.5,
             **self.halo_profile_params,
         )
 
@@ -1070,6 +1071,7 @@ class TracerHaloModel(DMHaloModel):
                 cm_relation=None,
                 mdef=self.mdef,
                 z=self.z,
+                sqrt_nu=self.nu**0.5,
                 **self.halo_profile_params,
             )
         else:
@@ -1088,6 +1090,7 @@ class TracerHaloModel(DMHaloModel):
                 cm_relation=None,
                 mdef=self.mdef,
                 z=self.z,
+                sqrt_nu=self.nu**0.5,
                 **tr_params,
             )
 
@@ -1129,6 +1132,7 @@ class TracerHaloModel(DMHaloModel):
             cm_relation=self.tracer_concentration,
             mdef=self.mdef,
             z=self.z,
+            sqrt_nu=self.nu**0.5,
             **tr_params,
         )
 

--- a/src/halomod/profiles.py
+++ b/src/halomod/profiles.py
@@ -98,15 +98,16 @@ class Profile(Component):
         The redshift of the halo
     """
 
-    _defaults = {}
+    _defaults = {'eta_bloat':0.0}
 
-    def __init__(self, cm_relation, mdef=SO_MEAN, z=0.0, cosmo=Planck15, **model_parameters):
+    def __init__(self, cm_relation, mdef=SO_MEAN, z=0.0, cosmo=Planck15, sqrt_nu=1.0, **model_parameters):
         self.mdef = mdef
         self.delta_halo = self.mdef.halo_overdensity_mean(z, cosmo)
         self.z = z
         self._cm_relation = cm_relation
         self.mean_dens = mdef.mean_density(z=z, cosmo=cosmo)
         self.mean_density0 = mdef.mean_density(0, cosmo=cosmo)
+        self.sqrt_nu = sqrt_nu
         self.has_lam = hasattr(self, "_l")
 
         super().__init__(**model_parameters)
@@ -144,7 +145,7 @@ class Profile(Component):
         """
         if c is None:
             c = self.cm_relation(m)
-        r = self.halo_mass_to_radius(m, at_z=at_z)
+        r = self.halo_mass_to_radius(m, at_z=at_z) * self.sqrt_nu**self.params['eta_bloat']
         return r / c
 
     def scale_radius(self, m: float | np.ndarray, at_z: bool = False) -> float | np.ndarray:


### PR DESCRIPTION
This PR mostly adds two functions / additions in order to `halomod` to mimic `HMcode2020` corrections to the base halo model implementation. Most notably:

- the ability to include the "halo bloating" as presented in Mead et al. 2020 through `eta` parameter.
- modification to any c(M) class in `halomod`, which allows for a arbitrary additional c(M) normalisation, which can be treated as a free parameter in MCMC analyses, agnostic of the c(M) model and their specific parameters (usefulness of this can be seen in Dvornik et al. 2023, for instance). This also introduces interpolation for concentrations where technically masses are not defined (mostly the case when using Colossus c(M)s), but after extensive tests with Catherine Heymans, that does not seem affect the accuracy and precision of resulting P(k).

What is more, there is a bug(?) in Bullock01 c(M) relation, that seems to cause the calculation to fail due to the fact that the `CambGrowth` factor is non-monotonic.