### PR TITLE
fix: use ``corr_auto_tracer`` instead of ``corr_gg`` 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Releases
 dev-version
 -----------
 
+Fixed
++++++
+* Fixed bug in ``ProjectedCF.projected_corr_gal`` calling deprecated ``corr_gg``.
+
 v2.1.0 [08 Jul 2021]
 ----------------------
 Features

--- a/src/halomod/integrate_corr.py
+++ b/src/halomod/integrate_corr.py
@@ -118,7 +118,7 @@ class ProjectedCF(HaloModel):
 
         To integrate perform a substitution y = x - r_p.
         """
-        return projected_corr_gal(self.r, self.corr_gg, self.rlim, self.rp)
+        return projected_corr_gal(self.r, self.corr_auto_tracer, self.rlim, self.rp)
 
 
 def projected_corr_gal(

--- a/tests/test_integrate_corr.py
+++ b/tests/test_integrate_corr.py
@@ -52,6 +52,18 @@ class TestProjCorr:
         wprp = projected_corr_gal(h.r, xir, h.rlim, self.rp)
         assert np.allclose(wprp, wprp_anl, rtol=5e-2)
 
+    def test_auto_gal_approx_power_law(self):
+        h = ProjectedCF(rp_min=self.rp, transfer_model="EH")
+        # fit the power-law to the auto-correlation function
+        # on small scales it should be a power-law
+        poly_pars = np.polyfit(np.log(h.r[h.r < 1]), np.log(h.corr_auto_tracer[h.r < 1]), 1)
+        gamma_xi = -poly_pars[0]
+        r0 = np.exp(poly_pars[1] / gamma_xi)
+        wp_approx = wprp_power_law(h.rp, r0, gamma_xi)
+        wp_gal = h.projected_corr_gal
+        # only test on small scales
+        assert np.allclose(wp_approx[h.rp < 0.1], wp_gal[h.rp < 0.1], rtol=5e-2)
+
 
 class TestAngularCF:
     @classmethod


### PR DESCRIPTION
The reason #171 was not caught by the test is because ``integrated_corr.projected_corr_gal`` was called in the tests instead of ``ProjectedCF.projected_corr_gal`` (should these two really have the same name?). A test using the actual galaxy corr function is added